### PR TITLE
rough in hero block and home block placeholders

### DIFF
--- a/es.po
+++ b/es.po
@@ -6,15 +6,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/components/StickyNav.js:46
-msgid "Friends Library"
-msgstr "La Biblioteca de los Amigos"
-
-#: src/components/HomePage.js:26
+#: src/components/Slideover.js:37
 msgid "Friends"
 msgstr "Amigos"
 
-#: src/components/FriendPage.js:43
+#: src/components/FriendPage.js:44
 msgid "Documents"
 msgstr "Documentos"
 
@@ -22,8 +18,8 @@ msgstr "Documentos"
 msgid "View Document"
 msgstr "Ver documento"
 
-#: src/components/DocumentPage.js:22
-#: src/components/SoftcoverPage.js:32
+#: src/components/DocumentPage.js:23
+#: src/components/SoftcoverPage.js:33
 msgid "by"
 msgstr "por"
 
@@ -43,15 +39,15 @@ msgstr "edición"
 msgid "Formats"
 msgstr "Formatos"
 
-#: src/components/SoftcoverPage.js:30
+#: src/components/SoftcoverPage.js:31
 msgid "Order paperback"
 msgstr "Orden de bolsillo"
 
-#: src/classes/Edition.js:43
+#: src/classes/Edition.js:45
 msgid "modernized"
 msgstr "modernizado"
 
-#: src/classes/Edition.js:45
+#: src/classes/Edition.js:43
 msgid "updated"
 msgstr "actualizado"
 
@@ -62,3 +58,7 @@ msgstr "original"
 #: src/components/DocumentTeaser.js:86
 msgid "Updated Available"
 msgstr "Actualizado disponible"
+
+#: src/components/StickyNav.js:46
+msgid "The Friends Library"
+msgstr "La Biblioteca de los Amigos"

--- a/src/components/HeroBlock.js
+++ b/src/components/HeroBlock.js
@@ -43,12 +43,12 @@ const element = css`
 export default () => (
   <Block className={element}>
     <h1>
-      Free e-books and audio books from early writers in the Society of Friends.
+      Dedicated to the preservation and free distribution of early Quaker writings
     </h1>
 
     <p>
       {/* eslint-disable max-len */}
-      This website exists to freely share the writings of early members of the Religious Society of Friends (Quakers), believing them to contain an amazingly helpful testimony to the purity and simplicity of primitive, biblical Christianity.
+      This website exists to freely share the writings of early members of the Religious Society of Friends (Quakers) in digital, audio, and printed formats, believing them to contain a powerful testimony to the purity and simplicity of primitive, biblical Christianity.
       {/* eslint-enable max-len */}
     </p>
   </Block>

--- a/src/components/HeroBlock.js
+++ b/src/components/HeroBlock.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react';
+import { css } from 'glamor';
+import Block from './Block';
+
+const element = css`
+  color: #fff;
+  background: #444;
+  background-size: cover;
+  position: relative;
+
+  :after {
+    content: "''";
+    position: absolute;
+    background: rgba(0, 0, 0, 0.45);
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+  }
+
+  > h1 {
+    margin: 8px 0 0;
+    font-size: 21px;
+    font-weight: 400;
+    line-height: 1.2em;
+    text-align: center;
+    position: relative;
+    color: #fff;
+    z-index: 2;
+  }
+
+  > p {
+    color: #fff;
+    background: rgba(0, 0, 0, 0.9);
+    padding: 10px;
+    border-radius: 10px;
+    margin: 20px 0 10px;
+  }
+`;
+
+export default () => (
+  <Block className={element}>
+    <h1>
+      Free e-books and audio books from early writers in the Society of Friends.
+    </h1>
+
+    <p>
+      {/* eslint-disable max-len */}
+      This website exists to freely share the writings of early members of the Religious Society of Friends (Quakers), believing them to contain an amazingly helpful testimony to the purity and simplicity of primitive, biblical Christianity.
+      {/* eslint-enable max-len */}
+    </p>
+  </Block>
+);

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,14 +1,11 @@
 // @flow
 import * as React from 'react';
+import HeroBlock from './HeroBlock';
 import TempBlock from './TempBlock';
 
 export default () => (
   <div>
-    <TempBlock
-      title="Hero/Intro Block"
-      bgColor="#444"
-      fontColor="#fff"
-    />
+    <HeroBlock />
     <TempBlock
       title="Featured Books"
       bgColor="#ccc"

--- a/src/components/SoftcoverPage.js
+++ b/src/components/SoftcoverPage.js
@@ -9,6 +9,7 @@ import url from 'lib/url';
 import PageTitle from './PageTitle';
 import ByLine from './ByLine';
 import Divider from './Divider';
+import Block from './Block';
 
 const address = css`
   margin-left: 1em;
@@ -26,7 +27,7 @@ type Props = {|
 |};
 
 export default ({ document }: Props) => (
-  <div>
+  <Block>
     <PageTitle>{t`Order paperback`}: {document.title}</PageTitle>
     <ByLine>
       {t`by`} <a href={url(document.friend)}>{document.friend.name}</a>
@@ -76,5 +77,5 @@ export default ({ document }: Props) => (
         </p>
       </React.Fragment>
     )}
-  </div>
+  </Block>
 );

--- a/src/components/StickyNav.js
+++ b/src/components/StickyNav.js
@@ -43,7 +43,7 @@ export default () => (
       ☰
     </span>
     <a href="/" className={logo}>
-      {t`Friends Library`}
+      {t`The Friends Library`}
     </a>
   </div>
 );


### PR DESCRIPTION
The purpose of this PR is to get the ball rolling on the main home blocks we sketched out, starting with the "Hero" block.  The rest of the blocks I just put in as multi-colored placeholders so we can see the proposed order.  But the Hero block I tried to take a stab at some text.  The purpose of the hero block is basically to quickly explain _what the site is_, or at least that's what I'm conceiving it's purpose to be.

Totally ignore the appearance of everything, let's just consider the content and purpose of these changes.  Let's try to think about questions like:

* do we want a hero block?
* does it belong up top?
* how do we succinctly explain what the site is?
* do we want a single title and a blurb, like I've roughed in here?
* longer blurb? shorter?
* should I have restated *The Friends Library* in the block title?

Please propose any changes to the text you can think of, including a 100% rewrite, I'm not terribly fond of what I've got here so far, but I'm trying not to get bogged down in the minutiae.

Below is a screenshot of what it looks like:

![2018-06-14_16-12-57](https://user-images.githubusercontent.com/7050938/41436233-05dc421a-6fef-11e8-881e-b1232b3382bd.png)

But even better would be to play around with the deploy preview, the link is here:

https://deploy-preview-40--en-evans.netlify.com/

By the way, any pull requests you checkout on this repo (`evans`), will have a fully-built test version of the site, you can always get to it by clicking here:

![2018-06-14_16-27-45](https://user-images.githubusercontent.com/7050938/41436551-ff9c0de4-6fef-11e8-9183-14d46191f75f.png)

And then here:

![2018-06-14_16-28-21](https://user-images.githubusercontent.com/7050938/41436624-3b54c5ce-6ff0-11e8-9006-918cd79e7b84.png)

Just note, that since I have the site deploying in 2 languages, sometimes the link shows up as english and sometimes spanish (I think based on which deploy finishes first).  You can always switch from one language to another by changing the `en-evans` to `es-evans` in the url, and vice versa.

So if the English deploy preview is:

`https://deploy-preview-40--en-evans.netlify.com/`

Then the Spanish would be:

`https://deploy-preview-40--es-evans.netlify.com/`

Closes https://github.com/friends-library/evans/issues/37.